### PR TITLE
Switch back to Ploutos v7 once support for `extra_cargo_deb_args` lands

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   package:
-    uses: maertsen/ploutos/.github/workflows/pkg-rust.yml@extra-deb-cargo-args
+    uses: nlnetlabs/ploutos/.github/workflows/pkg-rust.yml@v7
     with:
       package_build_rules: |
         image:


### PR DESCRIPTION
See also https://github.com/NLnetLabs/ploutos/pull/100